### PR TITLE
Multi-list-type renumbering (plus some utility file refactoring)

### DIFF
--- a/lua/autolist/auto.lua
+++ b/lua/autolist/auto.lua
@@ -120,6 +120,7 @@ end
 
 -- recalculates the current list scope
 function M.recal(override_start_num)
+	local types = get_lists()
 	local list_start_num
 	if override_start_num then
 		list_start_num = utils.get_list_start(override_start_num, get_lists())
@@ -130,10 +131,11 @@ function M.recal(override_start_num)
 	local list_start = fn.getline(list_start_num)
 	local list_indent = utils.get_indent_lvl(list_start)
 	local list_ordered = utils.is_ordered(list_start)
-	local list_marker = select(3, utils.is_list(list_start, get_lists()))
+	local list_marker = utils.get_marker(list_start, types)
 	if not list_marker then return end -- only returns list type if is list
 
-	local target = 2 -- start plus one
+	local target = utils.get_value_ordered(list_start) -- start plus one
+	print(target, list_start_num)
 	local linenum = list_start_num + 1
 	local line = fn.getline(linenum)
 	local line_marker_pat = select(2, utils.is_list(line, get_lists()))
@@ -147,24 +149,15 @@ function M.recal(override_start_num)
 	do
 		if line_indent == list_indent then
 			-- if its a list and its the same type of list
-			if line_marker_pat -- only returns linesub if is list
-				and line_ordered == list_ordered then
-				if line_ordered then
-					-- you set like 50 every time you press j, a few more cant hurt, right?
-					if not utils.set_value(linenum, line, target) then
-						print("p1")
-						return
-					end
-					-- only increase target if increased list
-					target = target + 1
-				else
-					fn.setline(".", (line:gsub(line_marker_pat, list_marker)))
-						print("p2")
-				end
+			-- only returns linesub if is list
+			if line_marker_pat then
+				utils.set_list_line(linenum, utils.get_marker(utils.ordered_add(list_start, target), get_lists()), get_lists())
+				-- only increase target if increased list
+				target = target + 1
 				-- escaped the child list
 				childlist_indent = -1
 			else
-						print("p3")
+				print(linenum)
 				-- same indent and isnt ordered
 				return
 			end

--- a/lua/autolist/utils.lua
+++ b/lua/autolist/utils.lua
@@ -6,8 +6,64 @@ local fn = vim.fn
 
 local M = {}
 
-local function vo(char)
-	return char:byte()
+-- search up ascii table
+-- value of char (value a)
+local function vo(char) return char:byte() end
+local va = vo('a')
+local vA = vo('A')
+local vz = vo('z')
+local vZ = vo('Z')
+local lenalph = 26 -- length of alphabet
+-- the difference between capital A and lenalph minus 1
+local diffAalph = 38 -- 27 plus 38 equals capital A in byteform
+
+-- ================================ utilities ============================== --
+
+local function char_add(char, amount)
+	return string.char(charwrap(char:byte() + amount))
+end
+
+local function str_add(str, amount)
+	-- if not a str (a string)
+	if tonumber(str) then
+		return tostring(tonumber(str) + amount)
+	end
+	return nil
+end
+
+local function number_to_char(number)
+	if number <= lenalph then
+		-- 1 equates to byteform of lowercase a
+		return number + va - 1
+	else
+		-- 27 equates to byteform of uppercase A
+		return number + diffAalph
+	end
+end
+
+-- reduce boilerplate
+local function exec_ordered(entry, func_digit, func_char, return_else, return_last)
+	local digit = entry:gsub("^%s*(%d+)%..*$", "%1", 1)
+	local char = entry:gsub("^%s*(%a)[.)].*$", "%1", 1)
+	if digit and digit ~= entry then
+		return func_digit(digit)
+	elseif char and char ~= entry then
+		return func_char(char)
+	else
+		return return_else
+	end
+	return return_last -- nil if not defined
+end
+
+local function char_to_number(char)
+	local byteform = char:byte()
+	if byteform >= va then
+		byteform = byteform - (va - 1) -- lowercase a is 1
+	elseif byteform >= vA then
+		-- capital A comes after lowercase z in numbered form
+		byteform = byteform - diffAalph -- (-64) + 26
+	end
+	return byteform
 end
 
 local function custom_round(a, b, val)
@@ -27,13 +83,7 @@ end
 -- increment z goes to A
 -- increment Z goes to a
 -- decrement vice verca
-function M.charwrap(byte)
-	-- search up ascii table
-	-- value of char (value a)
-	local va = vo('a')
-	local vA = vo('A')
-	local vz = vo('z')
-	local vZ = vo('Z')
+local function charwrap(byte)
 	if byte > vz then
 		return vA
 	-- smaller than 'z'
@@ -47,12 +97,24 @@ function M.charwrap(byte)
 	return byte
 end
 
-function M.str_add_digit(str, digit)
-	-- if not a str (a string)
-	if tonumber(str) then
-		return tostring(tonumber(str) + digit)
-	end
-	return nil
+-- ================================ setters ==( set, reset )================ --
+
+function M.set_list_line(linenum, marker, list_types)
+	local line = fn.getline(linenum)
+	local line = line:gsub(select(2, M.is_list(line, list_types)), marker)
+	fn.setline(linenum, line)
+end
+
+function M.set_value(line, linenum, val)
+	local function digitfunc() fn.setline(linenum, (line:gsub("%d+", val, 1))) end
+	local function charfunc() fn.setline(linenum, (line:gsub("%a", number_to_char(val), 1))) end
+	return exec_ordered(line, digitfunc, charfunc)
+end
+
+function M.reset_cursor_column()
+	local pos = fn.getpos(".")
+	pos[3] = 1
+	fn.setpos(".", pos)
 end
 
 -- set current line to {new_line} and set cursor to end of line
@@ -64,26 +126,109 @@ function M.set_current_line(new_line)
 	fn.setpos(".", pos)
 end
 
-function M.reset_cursor_column()
-	local pos = fn.getpos(".")
-	pos[3] = 1
-	fn.setpos(".", pos)
+-- ================================ getters ==( get )======================= --
+
+-- returns the number of tabs/spaces before a character
+function M.get_indent_lvl(entry) return #(entry:match("^%s*")) end
+
+-- returns the tabs/spaces before a character
+function M.get_indent(entry) return entry:match("^%s*") end
+
+-- get the place where the indented list began
+function M.get_parent_list(line) return M.get_list_start(line) - 1 end
+
+-- get the list marker from the line
+function M.get_marker(line, list_types) return select(3, M.is_list(line, list_types)) end
+
+-- trim whitespace
+function M.get_whitespace_trimmed(str) return str:gsub("%s*$", "") end
+
+-- delete % signs
+function M.get_percent_filtered(pat) return pat:gsub("%%", "") end
+
+-- get the value of the ordered list
+function M.get_value_ordered(entry)
+	local function digitfunc(input) return tonumber(input) end
+	return exec_ordered(entry, digitfunc, char_to_number, 0)
 end
 
---is ordered list
-function M.is_ordered(entry, rise)
-	-- increment only acts on incrementable (ordered) lists
-	local newval
-	if rise and rise > 0 then
-		newval = M.ordered_add(entry, 1)
+-- return add {amount} to the current ordered list
+function M.get_ordered_add(entry, amount)
+	if not amount then amount = 1 end -- defaults to increment
+	local function digitfunc(digit) return entry:gsub(digit, str_add(digit, amount), 1) end
+	local function charfunc(char) return entry:gsub(char, char_add(char, amount), 1) end
+	return exec_ordered(entry, digitfunc, charfunc, entry)
+end
+
+-- returns a lua pattern with the current vim tab value
+function M.get_tab_value()
+	if vim.opt.expandtab:get() then
+		local pattern = ""
+		local tabstop = vim.opt.tabstop:get()
+		-- get tabstop in spaces
+		for i = 1, tabstop, 1 do
+			pattern = pattern .. " "
+		end
+		return pattern, tabstop
 	else
-		newval = M.ordered_add(entry, -1)
+		return "\t", 1
 	end
-	-- if increment changed {entry} it is changable thus ordered
-	if newval ~= entry then
-		return newval
+end
+
+-- get the start of the current list scope (indent)
+function M.get_list_start(cur_linenum, list_types)
+	if not cur_linenum then
+		cur_linenum = fn.line(".")
+	end
+	local linenum = cur_linenum
+	local line = fn.getline(linenum)
+	local cur_indent = M.get_indent_lvl(line)
+	if cur_indent < 0 then cur_indent = 0 end
+	if list_types then
+		while (M.is_list(line, list_types)
+			and M.get_indent_lvl(line) >= cur_indent)
+			or M.get_indent_lvl(line) > cur_indent
+		do
+			linenum = linenum - 1
+			line = fn.getline(linenum)
+		end
+	else
+		while (M.is_ordered(line)
+			and M.get_indent_lvl(line) >= cur_indent)
+			or M.get_indent_lvl(line) > cur_indent
+		do
+			linenum = linenum - 1
+			line = fn.getline(linenum)
+		end
+	end
+	line = fn.getline(linenum + 1)
+	if M.is_list(line, list_types) then
+		return linenum + 1
 	end
 	return nil
+end
+
+-- ================================ checkers ==( does, is )================= --
+
+function M.does_table_contain(table, element)
+  for _, value in pairs(table) do
+    if value == element then
+      return true
+    end
+  end
+  return false
+end
+
+function M.is_same_list_type(la, lb, list_types)
+	for _, pat in ipairs(list_types) do
+		local _, asub = la:gsub(prefix .. pat .. suffix, "%1", 1)
+		local _, bsub = lb:gsub(prefix .. pat .. suffix, "%1", 1)
+		-- if they sub something, asub should be 1 cus this ---^ (and bsub)
+		if asub > 0 and bsub > 0 then
+			return true
+		end
+	end
+	return false
 end
 
 -- is a list, returns true, the pattern and the result of the pattern
@@ -106,181 +251,20 @@ function M.is_list(entry, list_types, more)
 	return false
 end
 
--- returns the number of tabs/spaces before a character
-function M.get_indent_lvl(entry)
-	return #(entry:match("^%s*"))
-end
-
--- returns the tabs/spaces before a character
-function M.get_indent(entry)
-	return entry:match("^%s*")
-end
-
--- returns a lua pattern with the current vim tab value
-function M.tab_value()
-	if vim.opt.expandtab:get() then
-		local pattern = ""
-		local tabstop = vim.opt.tabstop:get()
-		-- get tabstop in spaces
-		for i = 1, tabstop, 1 do
-			pattern = pattern .. " "
-		end
-		return pattern, tabstop
+--is ordered list
+function M.is_ordered(entry, rise)
+	-- increment only acts on incrementable (ordered) lists
+	local newval
+	if rise and rise > 0 then
+		newval = M.get_ordered_add(entry, 1)
 	else
-		return "\t", 1
+		newval = M.get_ordered_add(entry, -1)
 	end
-end
-
--- reduce boilerplate
-function M.exec_ordered(entry, func_digit, func_char, return_last, ...)
-	local digit = entry:gsub("^%s*(%d+)%..*$", "%1", 1)
-	local char = entry:gsub("^%s*(%a)[.)].*$", "%1", 1)
-	if digit then
-		return func_digit(entry, digit, ...)
-	elseif char then
-		return func_char(entry, char, ...)
-	end
-	return return_last -- nil if not defined
-end
-
-function M.get_value_ordered(entry)
-	local digit = entry:gsub("^%s*(%d+)%..*$", "%1", 1)
-	local char = entry:gsub("^%s*(%a)[.)].*$", "%1", 1)
-	if digit then
-		return tonumber(digit)
-	elseif char then
-		local byteform = char:byte()
-		if byteform > 96 then
-			-- lowercase a is 1
-			byteform = byteform - 96
-		elseif byteform > 64 then
-			-- (-64) + 26
-			-- capital A comes after lowercase z
-			byteform = byteform - 38
-		end
-		return byteform
-	end
-	return 0
-end
-
-function M.ordered_add(entry, amount)
-	-- defaults to increment
-	if not amount then amount = 1 end
-	local digit = entry:gsub(prefix .. "%d+)%..*$", "%1", 1)
-	local char = entry:gsub(prefix .. "%a)[.)].*$", "%1", 1)
-	-- if its an ordered list
-	if digit and digit ~= entry then
-		return entry:gsub(digit, M.str_add_digit(digit, amount), 1)
-	-- if it's an ascii list
-	elseif char and char ~= entry then
-		local byteform = charwrap(char:byte() + amount)
-		-- if bigger than lowercase z wrap to upper A and vice versa
-		return entry:gsub(char, string.char(byteform), 1)
-	end
-	-- return original if anything else
-	return entry
-end
-
--- returns successful
-function M.set_value(linenum, line, val)
-	local digit = line:gsub(prefix .. "%d+)%..*$", "%1", 1)
-	local char = line:gsub(prefix .. "%a)[.)].*$", "%1", 1)
-	if digit and digit ~= entry then
-		fn.setline(linenum, (line:gsub("%d+", val, 1)))
-		return true
-	elseif char and char ~= entry then
-		if val <= 26 then
-			-- 1 equates to byteform of lowercase a
-			val = val + 96
-		else
-			-- 27 equates to byteform of uppercase A
-			val = val + 38
-		end
-		fn.setline(linenum, line:gsub("%a", val, 1))
-		return true
-	else
-		fn.setline(linenum, line)
-	end
-end
-
-function M.get_list_start(cur_linenum, list_types)
-	if not cur_linenum then
-		cur_linenum = fn.line(".")
-	end
-	local linenum = cur_linenum
-	local line = fn.getline(linenum)
-	local cur_indent = M.get_indent_lvl(line)
-	if cur_indent < 0 then cur_indent = 0 end
-	if list_types then
-		while (M.is_list(line, list_types) and M.get_indent_lvl(line) >= cur_indent) or M.get_indent_lvl(line) > cur_indent do
-			linenum = linenum - 1
-			line = fn.getline(linenum)
-		end
-	else
-		while (M.is_ordered(line) and M.get_indent_lvl(line) >= cur_indent) or M.get_indent_lvl(line) > cur_indent do
-			linenum = linenum - 1
-			line = fn.getline(linenum)
-		end
-	end
-	line = fn.getline(linenum + 1)
-	if M.is_list(line, list_types) then
-		return linenum + 1
+	-- if increment changed {entry} it is changable thus ordered
+	if newval ~= entry then
+		return newval
 	end
 	return nil
-end
-
-function M.get_parent_list(line)
-	return M.get_list_start(line) - 1
-end
-
-function M.trim_end(str)
-	return str:gsub("%s*$", "")
-end
-
-function M.filter_pat(pat)
-	return pat:gsub("%%", "")
-end
-
-function M.table_contains(table, element)
-  for _, value in pairs(table) do
-    if value == element then
-      return true
-    end
-  end
-  return false
-end
-
--- returns the correct lists for the current filetype
-function M.get_lists(filetype_lists)
-	-- each table in filetype lists has the key of a filetype
-	-- each value has the tables (of lists) that it is assigned to
-	return filetype_lists[vim.bo.filetype]
-end
-
-function M.same_list_type(la, lb, list_types)
-	if not list_types then
-		print("error in utils(same_list_type)")
-	end
-	for _, pat in ipairs(list_types) do
-		local _, asub = la:gsub(prefix .. pat .. suffix, "%1", 1)
-		local _, bsub = lb:gsub(prefix .. pat .. suffix, "%1", 1)
-		-- if they sub something, they should be 1 cus this ---^
-		if asub > 0 and bsub > 0 then
-			return true
-		end
-	end
-	return false
-end
-
-function M.get_marker(line, list_types)
-	return select(3, M.is_list(line, list_types))
-end
-
-function M.set_list_line(linenum, marker, list_types)
-	local line = fn.getline(linenum)
-	print(linenum, marker)
-	local line = line:gsub(select(2, M.is_list(line, list_types)), marker)
-	fn.setline(linenum, line)
 end
 
 return M

--- a/lua/autolist/utils.lua
+++ b/lua/autolist/utils.lua
@@ -17,55 +17,6 @@ local lenalph = 26 -- length of alphabet
 -- the difference between capital A and lenalph minus 1
 local diffAalph = 38 -- 27 plus 38 equals capital A in byteform
 
--- ================================ utilities ============================== --
-
-local function char_add(char, amount)
-	return string.char(charwrap(char:byte() + amount))
-end
-
-local function str_add(str, amount)
-	-- if not a str (a string)
-	if tonumber(str) then
-		return tostring(tonumber(str) + amount)
-	end
-	return nil
-end
-
-local function number_to_char(number)
-	if number <= lenalph then
-		-- 1 equates to byteform of lowercase a
-		return number + va - 1
-	else
-		-- 27 equates to byteform of uppercase A
-		return number + diffAalph
-	end
-end
-
--- reduce boilerplate
-local function exec_ordered(entry, func_digit, func_char, return_else, return_last)
-	local digit = entry:gsub("^%s*(%d+)%..*$", "%1", 1)
-	local char = entry:gsub("^%s*(%a)[.)].*$", "%1", 1)
-	if digit and digit ~= entry then
-		return func_digit(digit)
-	elseif char and char ~= entry then
-		return func_char(char)
-	else
-		return return_else
-	end
-	return return_last -- nil if not defined
-end
-
-local function char_to_number(char)
-	local byteform = char:byte()
-	if byteform >= va then
-		byteform = byteform - (va - 1) -- lowercase a is 1
-	elseif byteform >= vA then
-		-- capital A comes after lowercase z in numbered form
-		byteform = byteform - diffAalph -- (-64) + 26
-	end
-	return byteform
-end
-
 local function custom_round(a, b, val)
 	-- if val bigger than the middle of a and b
 	if val > (a + b) / 2 then
@@ -95,6 +46,58 @@ local function charwrap(byte)
 		return custom_round(vZ, va, byte) == va and vZ or vA
 	end
 	return byte
+end
+
+-- just remember, to use a local function inside a function, you must
+-- declare the local function before the current function.
+
+-- ================================ utilities ============================== --
+
+local function char_add(char, amount)
+	return string.char(charwrap(char:byte() + amount))
+end
+
+local function str_add(str, amount)
+	-- if not a str (a string)
+	if tonumber(str) then
+		return tostring(tonumber(str) + amount)
+	end
+	return nil
+end
+
+local function number_to_char(number)
+	if number <= lenalph then
+		-- 1 equates to byteform of lowercase a
+		return string.char(number + va - 1)
+	else
+		-- 27 equates to byteform of uppercase A
+		return string.char(number + diffAalph)
+	end
+end
+
+-- reduce boilerplate
+local function exec_ordered(entry, func_digit, func_char, return_else, return_last)
+	local digit = entry:gsub("^%s*(%d+)%..*$", "%1", 1)
+	local char = entry:gsub("^%s*(%a)[.)].*$", "%1", 1)
+	if digit and digit ~= entry then
+		return func_digit(digit)
+	elseif char and char ~= entry then
+		return func_char(char)
+	else
+		return return_else
+	end
+	return return_last -- nil if not defined
+end
+
+local function char_to_number(char)
+	local byteform = char:byte()
+	if byteform >= va then
+		byteform = byteform - (va - 1) -- lowercase a is 1
+	elseif byteform >= vA then
+		-- capital A comes after lowercase z in numbered form
+		byteform = byteform - diffAalph -- (-64) + 26
+	end
+	return byteform
 end
 
 -- ================================ setters ==( set, reset )================ --

--- a/lua/autolist/utils.lua
+++ b/lua/autolist/utils.lua
@@ -114,11 +114,11 @@ function M.is_list(entry, list_types, more)
 	else
 		more = ""
 	end
-	for _, pat in ipairs(list_types) do
+	for i, pat in ipairs(list_types) do
 		local sub, nsubs = entry:gsub(prefix .. pat .. more .. suffix, "%1", 1)
 		-- if replaced something
 		if nsubs > 0 then
-			return true, pat, sub
+			return true, pat, sub, i
 		end
 	end
 	return false
@@ -170,13 +170,13 @@ function M.get_value_ordered(entry)
 end
 
 -- returns successful
-function M.set_value_ordered(linenum, line, val)
+function M.set_value(linenum, line, val)
 	local digit = line:gsub(prefix .. "%d+)%..*$", "%1", 1)
 	local char = line:gsub(prefix .. "%a)[.)].*$", "%1", 1)
-	if digit then
+	if digit and digit ~= entry then
 		fn.setline(linenum, (line:gsub("%d+", val, 1)))
 		return true
-	elseif char then
+	elseif char and char ~= entry then
 		if val <= 26 then
 			-- 1 equates to byteform of lowercase a
 			val = val + 96
@@ -187,7 +187,7 @@ function M.set_value_ordered(linenum, line, val)
 		fn.setline(linenum, line:gsub("%a", val, 1))
 		return true
 	else
-		return false
+		fn.setline(linenum, line)
 	end
 end
 
@@ -245,5 +245,19 @@ function M.get_lists(filetype_lists)
 	return filetype_lists[vim.bo.filetype]
 end
 
+function M.same_list_type(la, lb, list_types)
+	if not list_types then
+		print("error in utils(same_list_type)")
+	end
+	for _, pat in ipairs(list_types) do
+		local _, asub = la:gsub(prefix .. pat .. suffix, "%1", 1)
+		local _, bsub = lb:gsub(prefix .. pat .. suffix, "%1", 1)
+		-- if they sub something, they should be 1 cus this ---^
+		if asub > 0 and bsub > 0 then
+			return true
+		end
+	end
+	return false
+end
 
 return M


### PR DESCRIPTION
basically the title: implemented multi list type renumbering (previously `recal()` could only recalculate ordered lists, but now it also recalculates unordered lists, by making the list markers follow logical indents. 

I also did some utility file refactoring, separating all the public functions into `setters`, `getters` and `checkers`, and the functions are now sorted in each section by function length (more or less).