### PR TITLE
fix: don't modify text if not currently in a list

### DIFF
--- a/lua/autolist/auto.lua
+++ b/lua/autolist/auto.lua
@@ -97,6 +97,8 @@ function M.new(motion, mapping)
 		prev_line = utils.set_ordered_value(fn.getline(fn.line(".") + 1), 0)
 	end
 
+  if not utils.is_list(prev_line, filetype_lists) then return end
+
 	local matched = false
 
 	-- ipairs is used to optimise list_types (most used checked first)


### PR DESCRIPTION
for autolist.new, don't setline if nothing is changed. (kinda obvious, but whatever. I might have had a reason for this in the past, but i can't remember what it is, and this fixes #43, so imma do it.)