### PR TITLE
v3.0.0

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,5 +1,4 @@
 #+author: Dean Gao
-#+email: gao.dean@hotmail.com
 #+startup: overview
 
 #+begin_html
@@ -45,27 +44,41 @@ as well:
 
 #+begin_src lua
   {
-    "gaoDean/autolist.nvim",
-    ft = {
-      "markdown",
-      "text",
-      "tex",
-      "plaintex",
-    },
-    config = function()
-      local autolist = require("autolist")
-      autolist.setup()
-      vim.keymap.set("i", "<tab>", "<cmd>AutolistTab<cr>")
-      vim.keymap.set("i", "<s-tab>", "<cmd>AutolistShiftTab<cr>")
-      vim.keymap.set("n", ">>", ">><cmd>AutolistRecalculate<cr>")
-      vim.keymap.set("n", "<<", "<<<cmd>AutolistRecalculate<cr>")
-      vim.keymap.set("i", "<CR>", "<CR><cmd>AutolistNewBullet<cr>")
-      vim.keymap.set("n", "o", "o<cmd>AutolistNewBullet<cr>")
-      vim.keymap.set("n", "O", "O<cmd>AutolistNewBulletBefore<cr>")
-      vim.keymap.set("n", "<C-r>", "<cmd>AutolistRecalculate<cr>")
-      autolist.create_mapping_hook("n", "<leader>x", autolist.invert_entry, "")
-    end,
+      "gaoDean/autolist.nvim",
+      ft = {
+          "markdown",
+          "text",
+          "tex",
+          "plaintex",
+          "norg",
+      },
+      config = function()
+          require("autolist").setup()
+
+          vim.keymap.set("i", "<tab>", "<cmd>AutolistTab<cr>")
+          vim.keymap.set("i", "<s-tab>", "<cmd>AutolistShiftTab<cr>")
+          vim.keymap.set("i", "<CR>", "<CR><cmd>AutolistNewBullet<cr>")
+          vim.keymap.set("n", "o", "o<cmd>AutolistNewBullet<cr>")
+          vim.keymap.set("n", "O", "O<cmd>AutolistNewBulletBefore<cr>")
+          vim.keymap.set("n", "<CR>", "<cmd>AutolistToggleCheckbox<cr><CR>")
+          vim.keymap.set("n", "<C-r>", "<cmd>AutolistRecalculate<cr>")
+
+          -- cycle list types with dot-repeat
+          vim.keymap.set("n", "<leader>cn", require("autolist").cycle_next_dr, { expr = true })
+          vim.keymap.set("n", "<leader>cp", require("autolist").cycle_prev_dr, { expr = true })
+
+          -- if you don't want dot-repeat
+          -- vim.keymap.set("n", "<leader>cn", "<cmd>AutolistCycleNext<cr>")
+          -- vim.keymap.set("n", "<leader>cp", "<cmd>AutolistCycleNext<cr>")
+
+          -- functions to recalculate list on edit
+          vim.keymap.set("n", ">>", ">><cmd>AutolistRecalculate<cr>")
+          vim.keymap.set("n", "<<", "<<<cmd>AutolistRecalculate<cr>")
+          vim.keymap.set("n", "dd", "dd<cmd>AutolistRecalculate<cr>")
+          vim.keymap.set("v", "d", "d<cmd>AutolistRecalculate<cr>")
+      end,
   },
+    
 #+end_src
 
 * Usage
@@ -86,8 +99,8 @@ as well:
 7. You can even go back and delete a line. The list will be
    automatically renumbered.
 
-#+begin_example
-- [x] checkboxes can be toggled with autolist.invert_entry, which is "<leader>x" if you used the default mappings
+#+begin_src markdown
+- [x] checkboxes can be toggled with `:AutolistToggleCheckbox`, which is bound to `return` in normal mode if you used the default mappings
 
 1. [x] these can also be numbered
 
@@ -101,48 +114,29 @@ MX. All the way up
 MXI. to infinity
 MXII. It really will continue forever
 MXIII. -I think
-#+end_example
 
-- if the list type is not a checkbox, invert entry converts it from an
-  ordered list to an unordered list (and vice versa)
-- below is a copy of this list, but after inverting
+- you can cycle the type of the list with `:AutolistCycleNext` and `:AutolistCyclePrev`
+- below is a copy of this list after cycling twice
 
-1. if the list type is not a checkbox, invert entry converts it from an
-   ordered list to an unordered list (and vice versa)
-2. below is a copy of this list, but after inverting
-
-** Mappings
-Most of the mappings you'll create will look like this:
-
-#+begin_src lua
-autolist = require("autolist")
-autolist.setup()
-autolist.create_mapping_hook("i", "<cr>", autolist.new)
-#+end_src
-
-The =create_mapping_hook= function is just for easier UX, but it is just a wrapper around =vim.keymap.set= to prevent clashes between plugins. If you find that it doesn't clash with anything, you can just use =vim.keymap.set=.
-
-It starts with the helper function, then the mode, mapping and the hook function. With the above mapping, it runs =autolist.new= *after* =<cr>=
-is pressed.
-
-The =alias= argument converts the =mapping= to =alias= when passing to the function, for example in the below mapping, =<s-tab>= is captured and converted to =<c-d>= to pass to the function.
-
-#+begin_src lua
-autolist.create_mapping_hook("i", "<s-tab>", autolist.indent, "<c-d>")
-#+end_src
-
-Here are all the public functions:
-
-#+begin_src lua
-autolist.new() -- new list entry after current line
-autolist.new_before() -- new list entry before current line
-autolist.indent() -- indent the current list, replacing <tab> with indent line when it sees fit
-autolist.invert_entry() -- inverts the list entry, described above
-autolist.force_recalculate() -- recalculates the list
+1. you can cycle the type of the list with `:AutolistCycleNext` and `:AutolistCyclePrev`
+2. below is a copy of this list after cycling twice
 #+end_src
 
 * Configuration
 #+begin_src lua
+local list_patterns = {
+    neorg_1 = "%-",
+    neorg_2 = "%-%-",
+    neorg_3 = "%-%-%-",
+    neorg_4 = "%-%-%-%-",
+    neorg_5 = "%-%-%-%-%-",
+    unordered = "[-+*]", -- - + *
+    digit = "%d+[.)]", -- 1. 2. 3.
+    ascii = "%a[.)]", -- a) b) c)
+    roman = "%u*[.)]", -- I. II. III.
+    latex_item = "\\item",
+}
+
 local default_config = {
   enabled = true,
   colon = { -- if a line ends in a colon
@@ -150,41 +144,41 @@ local default_config = {
     indent_raw = true, -- above, but doesn't need to be in a list to work
     preferred = "-", -- what the new list starts with (can be `1.` etc)
   },
-  invert = { -- Inverts the list type (ol -> ul, ul -> ol, [ ] -> [x])
-    indent = false, -- when on top level list, pressing invert inverts the list and indents it
-    toggles_checkbox = true, -- if pressing invert toggles checkbox
-    ul_marker = "-", -- when from ordered list to unordered, set marker to whatever this is
-    ol_incrementable = "1", -- same thing above but for ordered
+  cycle = { -- Cycles the list type in order
+      "-",   -- whatever you put here will match the first item in your list
+      "*",   -- for example if your list started with a `-` it would go to `*`
+      "1.",  -- this says that if your list starts with a `*` it would go to `1.`
+      "1)",  -- this all leverages the power of recalculate.
+      "a)",  -- i spent many hours on that function
+      "I.",  -- try it, change the first bullet in a list to `a)`, and press recalculate
   },
-  lists = { -- configures list behavio
+  lists = { -- configures list behaviours
     -- Each key in lists represents a filetype.
     -- The value is a table of all the list patterns that the filetype implements.
-    -- See how to define your custom list below
-    -- You can see a few preloaded options in the default configuration such as "unordered" and "digit"
-    -- of which the full set you can find in the config.list_patterns
+    -- See how to define your custom list below in the readme.
     -- You must put the file name for the filetype, not the file extension
     -- To get the "file name", it is just =:set filetype?= or =:se ft?=.
     markdown = {
-      "unordered",
-      "digit",
-      "ascii", -- specifies activate the ascii list type for markdown files
-      "roman", -- see below on the list types
+      list_patterns.unordered,
+      list_patterns.digit,
+      list_patterns.ascii, -- for example this specifies activate the ascii list
+      list_patterns.roman, -- type for markdown files.
     },
     text = {
-      "unordered",
-      "digit",
-      "ascii",
-      "roman",
+      list_patterns.unordered,
+      list_patterns.digit,
+      list_patterns.ascii,
+      list_patterns.roman,
     },
-    tex = { "latex_item" },
-    plaintex = { "latex_item" },
-  },
-  list_patterns = { -- custom list types: see README -> Configuration -> defining custom lists
-    unordered = "[-+*]", -- - + *
-    digit = "%d+[.)]", -- 1. 2. 3.
-    ascii = "%a[.)]", -- a) b) c)
-    roman = "%u*[.)]", -- I. II. III.
-    latex_item = "\\item",
+    norg = {
+        list_patterns.neorg_1,
+        list_patterns.neorg_2,
+        list_patterns.neorg_3,
+        list_patterns.neorg_4,
+        list_patterns.neorg_5,
+    },
+    tex = { list_patterns.latex_item },
+    plaintex = { list_patterns.latex_item },
   },
   checkbox = {
     left = "%[", -- the left checkbox delimiter (you could change to "%(" for brackets)
@@ -195,6 +189,20 @@ local default_config = {
   -- this is all based on lua patterns, see "Defining custom lists" for a nice article to learn them
 }
 #+end_src
+** Mappings
+
+Here are all the public functions:
+
++ ~AutolistNewBullet~ : adds a new bullet on the current line
++ ~AutolistRecalculate~ : recalculates an ordered list
++ ~AutolistToggleCheckbox~ : toggles a checkbox on the current line
++ ~AutolistCycleNext~ : cycles the list type forwards according to ~config.cycle~
++ ~AutolistCyclePrev~ : above, but backwards
+
+All of the functions described above have lua counterparts which are just snake case versions of the pascal case commands. For example ~AutolistNewBullet~ has the snake case counterpart ~require("autolist").new_bullet()~
+
+There are two special functions for lua: ~require("autolist").cycle_next_dr~ and ~require("autolist").cycle_prev_dr~, which provide dot-repeatable versions of ~AutolistCycleNext~ and ~AutolistCyclePrev~.
+
 ** Defining custom lists
 In a nutshell, all you need to do is make a lua pattern match that
 allows autolist to find your new list marker.
@@ -205,16 +213,17 @@ patterns in the preloaded patterns section.
 Here's how to define your custom list:
 
 #+begin_src lua
+local my_list_patterns = {
+      test = "%a[.)]"
+} 
+
 require('autolist').setup({
-    lists = {
+        lists = {
             markdown = {
                 "%a[.)]", -- insert your custom lua pattern here
-                "test", -- or use the test pattern defined below
+                my_list_patterns.test, -- or use a variable
             },
         },
-    }
-    list_patterns = {
-        test = "%a[.)]", -- insert your custom lua pattern here
     }
 })
 #+end_src

--- a/README.org
+++ b/README.org
@@ -44,28 +44,28 @@ This is using lazy.nvim, but you can adapt it to other package managers
 as well:
 
 #+begin_src lua
-{
-  "gaoDean/autolist.nvim",
-  ft = {
-    "markdown",
-    "text",
-    "tex",
-    "plaintex",
+  {
+    "gaoDean/autolist.nvim",
+    ft = {
+      "markdown",
+      "text",
+      "tex",
+      "plaintex",
+    },
+    config = function()
+      local autolist = require("autolist")
+      autolist.setup()
+      vim.keymap.set("i", "<tab>", "<cmd>AutolistTab<cr>")
+      vim.keymap.set("i", "<s-tab>", "<cmd>AutolistShiftTab<cr>")
+      vim.keymap.set("n", ">>", ">><cmd>AutolistRecalculate<cr>")
+      vim.keymap.set("n", "<<", "<<<cmd>AutolistRecalculate<cr>")
+      vim.keymap.set("i", "<CR>", "<CR><cmd>AutolistNewBullet<cr>")
+      vim.keymap.set("n", "o", "o<cmd>AutolistNewBullet<cr>")
+      vim.keymap.set("n", "O", "O<cmd>AutolistNewBulletBefore<cr>")
+      vim.keymap.set("n", "<C-r>", "<cmd>AutolistRecalculate<cr>")
+      autolist.create_mapping_hook("n", "<leader>x", autolist.invert_entry, "")
+    end,
   },
-  config = function()
-    local autolist = require("autolist")
-    autolist.setup()
-    autolist.create_mapping_hook("i", "<CR>", autolist.new)
-    autolist.create_mapping_hook("i", "<Tab>", autolist.indent)
-    autolist.create_mapping_hook("i", "<S-Tab>", autolist.indent, "<C-D>")
-    autolist.create_mapping_hook("n", "o", autolist.new)
-    autolist.create_mapping_hook("n", "O", autolist.new_before)
-    autolist.create_mapping_hook("n", ">>", autolist.indent)
-    autolist.create_mapping_hook("n", "<<", autolist.indent)
-    autolist.create_mapping_hook("n", "<C-r>", autolist.force_recalculate)
-    autolist.create_mapping_hook("n", "<leader>x", autolist.invert_entry, "")
-  end,
-},
 #+end_src
 
 * Usage

--- a/README.org
+++ b/README.org
@@ -18,6 +18,8 @@
 </p>
 #+end_html
 
+⚠️ If you've just updated the plugin, read over this document to see what's new. ⚠️
+
 https://user-images.githubusercontent.com/97860672/193787598-56abba13-3710-43d1-b8b3-4fd81074dbd4.mp4
 
 * Why autolist.nvim
@@ -85,7 +87,7 @@ as well:
 1. Type in a list marker (a list marker is just the delimiter used to
    start the list (=-|+|*= or =1.|2.|3.=)
 2. Type in your content
-3. When you're ready, press =enter=/=return= and a new list entry will
+3. When you're ready, press =enter= / =return= and a new list entry will
    be automatically created
 4. If you're cursor is at the end of the line, you can indent your list
    with tab. When indenting, ordered lists will automatically be reset
@@ -94,7 +96,7 @@ as well:
    dedented. When dedenting, markers will automatically be changed
    through context awareness, to the correct marker such that the list
    continues logically
-6. Lastly, when you're done, pressing =enter=/=return= on an empty list
+6. Lastly, when you're done, pressing =enter= / =return= on an empty list
    entry will delete it, leaving you with a fresh new sentence.
 7. You can even go back and delete a line. The list will be
    automatically renumbered.

--- a/lua/autolist/auto.lua
+++ b/lua/autolist/auto.lua
@@ -77,8 +77,7 @@ function M.recalculate(override_start_num, reset_list)
 				utils.set_line_marker(
 					linenum,
 					utils.get_marker(val, types),
-					types,
-					line:match(pat_checkbox)
+					types
 				)
 				target = target + 1 -- only increase target if increased list
 				prev_indent = -1 -- escaped the child list

--- a/lua/autolist/auto.lua
+++ b/lua/autolist/auto.lua
@@ -35,15 +35,6 @@ local function get_lists()
 	return config.lists[vim.bo.filetype]
 end
 
-local function checkbox_is_filled(line)
-	if line:match(checkbox_filled_pat) then
-		return true
-	elseif line:match(checkbox_empty_pat) then
-		return false
-	end
-	return nil
-end
-
 -- recalculates the current list scope
 function M.recalculate(override_start_num, reset_list)
 	-- the var base names: list and line
@@ -127,7 +118,7 @@ local function get_bullet_from(line, pattern)
     local matched_bare = line:match("^%s*"
                                     .. pattern
                                     .. "%s*") -- only bullet, no checkbox
-    local matched_with_checkbox = line:match("^(%s*"
+    local matched_with_checkbox = line:match("^%s*"
                                              .. pattern
                                              .. "%s*"
                                              .. "%[.%]"
@@ -203,6 +194,7 @@ local function handle_indent(before, after)
     else
         press(before, "i")
     end
+end
 
 function M.shift_tab()
     handle_indent("<s-tab>", "<c-d>")
@@ -211,6 +203,31 @@ end
 function M.tab()
     handle_indent("<tab>", "<c-t>")
 end
+
+local function checkbox_is_filled(line)
+	if line:match(checkbox_filled_pat) then
+		return true
+	elseif line:match(checkbox_empty_pat) then
+		return false
+	end
+end
+
+function M.toggle_checkbox()
+    local cur_line = fn.getline(".")
+    local filled = checkbox_is_filled(cur_line)
+    if filled == true then
+        -- replace current line's empty checkbox with filled checkbox
+        fn.setline(".", (cur_line:gsub(checkbox_filled_pat, checkbox_empty, 1)))
+        -- it is a checkbox, but not empty
+    elseif filled == false then
+        -- replace current line's filled checkbox with empty checkbox
+        fn.setline(".", (cur_line:gsub(checkbox_empty_pat, checkbox_filled, 1)))
+    end
+end
+
+-- function M.cycle()
+
+-- end
 
 local function invert()
 	local cur_line = fn.getline(".")

--- a/lua/autolist/auto.lua
+++ b/lua/autolist/auto.lua
@@ -163,7 +163,6 @@ end
 
 function M.new(motion, mapping, prev_line_override)
 	local filetype_lists = get_lists()
-    print(filetype_lists)
 
     if motion == nil then
         next_keypress = mapping
@@ -180,7 +179,6 @@ function M.new(motion, mapping, prev_line_override)
     if not filetype_lists then return nil end
     if is_in_code_fence() then return nil end
 
-    print(prev_line_override)
     -- if new_bullet_before, prev_line should be the line below
     local prev_line = fn.getline(fn.line(".") + (prev_line_override and 1 or -1))
 

--- a/lua/autolist/auto.lua
+++ b/lua/autolist/auto.lua
@@ -234,8 +234,30 @@ local function index_of(str, list)
     end
 end
 
+-- with dotrepeat
+function M.next_list_type_dr(motion)
+    if motion == nil then
+        vim.o.operatorfunc = "v:lua.require'autolist'.next_list_type_dr"
+        return "g@l"
+    end
+    for i = 1, vim.v.count1 do
+        M.next_list_type()
+    end
+end
+
 function M.next_list_type()
     M.cycle_list_types()
+end
+
+-- with dotrepeat
+function M.prev_list_type_dr(motion)
+    if motion == nil then
+        vim.o.operatorfunc = "v:lua.require'autolist'.prev_list_type_dr"
+        return "g@l"
+    end
+    for i = 1, vim.v.count1 do
+        M.prev_list_type()
+    end
 end
 
 function M.prev_list_type()

--- a/lua/autolist/auto.lua
+++ b/lua/autolist/auto.lua
@@ -36,7 +36,7 @@ local function get_lists()
 end
 
 -- recalculates the current list scope
-function M.recalculate(override_start_num, reset_list)
+function M.recalculate(override_start_num)
 	-- the var base names: list and line
 	-- x is the actual line (fn.getline)
 	-- x_num is the line number (fn.line)
@@ -44,6 +44,7 @@ function M.recalculate(override_start_num, reset_list)
 
 	local types = get_lists()
 	local list_start_num
+    local reset_list
 	if override_start_num then
 		list_start_num = override_start_num
 	else
@@ -98,14 +99,6 @@ function M.recalculate(override_start_num, reset_list)
 		linenum = linenum + 1
 		line = fn.getline(linenum)
 		line_indent = utils.get_indent_lvl(line)
-	end
-end
-
-local function check_recalculate(force)
-	if config.recalculate_full then
-		recalculate()
-	else
-		recalculate(utils.get_list_start(fn.line("."), get_lists()))
 	end
 end
 

--- a/lua/autolist/auto.lua
+++ b/lua/autolist/auto.lua
@@ -227,37 +227,7 @@ local function index_of(str, list)
     end
 end
 
--- with dotrepeat
-function M.next_list_type_dr(motion)
-    if motion == nil then
-        vim.o.operatorfunc = "v:lua.require'autolist'.next_list_type_dr"
-        return "g@l"
-    end
-    for i = 1, vim.v.count1 do
-        M.next_list_type()
-    end
-end
-
-function M.next_list_type()
-    M.cycle_list_types()
-end
-
--- with dotrepeat
-function M.prev_list_type_dr(motion)
-    if motion == nil then
-        vim.o.operatorfunc = "v:lua.require'autolist'.prev_list_type_dr"
-        return "g@l"
-    end
-    for i = 1, vim.v.count1 do
-        M.prev_list_type()
-    end
-end
-
-function M.prev_list_type()
-    M.cycle_list_types(true)
-end
-
-function M.cycle_list_types(cycle_backward)
+local function cycle(cycle_backward)
 	local filetype_lists = get_lists()
     local list_start = utils.get_list_start(fn.line("."), filetype_lists)
 
@@ -279,6 +249,37 @@ function M.cycle_list_types(cycle_backward)
 
     utils.set_line_marker(list_start, target_bullet, filetype_lists)
     M.recalculate()
+end
+
+
+-- with dotrepeat
+function M.cycle_next_dr(motion)
+    if motion == nil then
+        vim.o.operatorfunc = "v:lua.require'autolist'.cycle_next_dr"
+        return "g@l"
+    end
+    for i = 1, vim.v.count1 do
+        M.cycle_next()
+    end
+end
+
+-- with dotrepeat
+function M.cycle_prev_dr(motion)
+    if motion == nil then
+        vim.o.operatorfunc = "v:lua.require'autolist'.cycle_prev_dr"
+        return "g@l"
+    end
+    for i = 1, vim.v.count1 do
+        M.cycle_prev()
+    end
+end
+
+function M.cycle_prev()
+    cycle(true)
+end
+
+function M.cycle_next()
+    cycle()
 end
 
 return M

--- a/lua/autolist/auto.lua
+++ b/lua/autolist/auto.lua
@@ -119,28 +119,6 @@ local function check_recal(force)
 	end
 end
 
-local function modify(prev, pattern)
-	-- the brackets capture {pattern} and they release on %1
-	local matched, nsubs = prev:gsub("^(%s*" .. pattern .. "%s).*$", "%1", 1)
-	if nsubs == 0 then
-		matched, nsubs = prev:gsub("^(%s*" .. pattern .. ")$", "%1", 1)
-	end
-	-- trim off spaces
-	if
-		utils.get_whitespace_trimmed(matched)
-		== utils.get_whitespace_trimmed(prev)
-	then
-		-- if replaced smth
-		if nsubs == 1 then
-			-- filler return value
-			return { replaced = true }
-		else
-			return { replaced = false }
-		end
-	end
-	return utils.get_ordered_add(matched, 1)
-end
-
 function M.new_before(motion, mapping)
 	return M.new(motion, mapping, true)
 end
@@ -166,7 +144,7 @@ local function is_in_code_fence()
 end
 
 local function find_suitable_bullet(line, filetype_lists, del_above)
-	-- ipairs is used to optimise list_types (most used checked first)
+	-- ipairs is used to optimise list_types (and say who has priority)
 	for i, filetype_specific_pattern in ipairs(filetype_lists) do
         local bullet = get_bullet_from(line, filetype_specific_pattern)
 
@@ -185,6 +163,7 @@ end
 
 function M.new(motion, mapping, prev_line_override)
 	local filetype_lists = get_lists()
+    print(filetype_lists)
 
     if motion == nil then
         next_keypress = mapping

--- a/lua/autolist/auto.lua
+++ b/lua/autolist/auto.lua
@@ -249,7 +249,7 @@ function M.cycle_list_types(cycle_backward)
     if index_in_cycle + 1 > #config.cycle then index_in_cycle = 1 end
     if index_in_cycle - 1 <= 0 then index_in_cycle = #config.cycle end
 
-    local target_bullet = config.cycle[index_in_cycle + (cycle_backward and 1 or -1)]
+    local target_bullet = config.cycle[index_in_cycle + (cycle_backward and -1 or 1)]
 
     utils.set_line_marker(list_start, target_bullet, filetype_lists)
     M.recalculate()

--- a/lua/autolist/config.lua
+++ b/lua/autolist/config.lua
@@ -11,7 +11,7 @@ local default_config = {
     ul_marker = "-", -- when from ordered list to unordered, set marker to whatever this is
     ol_incrementable = "1", -- same thing above but for ordered
   },
-  lists = { -- configures list behavio
+  lists = { -- configures list behaviours
     -- Each key in lists represents a filetype.
     -- The value is a table of all the list patterns that the filetype implements.
     -- See how to define your custom list below
@@ -31,10 +31,22 @@ local default_config = {
       "ascii",
       "roman",
     },
+    neorg = {
+        "neorg_1",
+        "neorg_2",
+        "neorg_3",
+        "neorg_4",
+        "neorg_5",
+    },
     tex = { "latex_item" },
     plaintex = { "latex_item" },
   },
   list_patterns = { -- custom list types: see README -> Configuration -> defining custom lists
+    neorg_1 = "%-",
+    neorg_2 = "%-%-",
+    neorg_3 = "%-%-%-",
+    neorg_4 = "%-%-%-%-",
+    neorg_5 = "%-%-%-%-%-",
     unordered = "[-+*]", -- - + *
     digit = "%d+[.)]", -- 1. 2. 3.
     ascii = "%a[.)]", -- a) b) c)

--- a/lua/autolist/config.lua
+++ b/lua/autolist/config.lua
@@ -1,3 +1,16 @@
+local list_patterns = {
+    neorg_1 = "%-",
+    neorg_2 = "%-%-",
+    neorg_3 = "%-%-%-",
+    neorg_4 = "%-%-%-%-",
+    neorg_5 = "%-%-%-%-%-",
+    unordered = "[-+*]", -- - + *
+    digit = "%d+[.)]", -- 1. 2. 3.
+    ascii = "%a[.)]", -- a) b) c)
+    roman = "%u*[.)]", -- I. II. III.
+    latex_item = "\\item",
+}
+
 local default_config = {
   enabled = true,
   colon = { -- if a line ends in a colon
@@ -16,44 +29,30 @@ local default_config = {
   lists = { -- configures list behaviours
     -- Each key in lists represents a filetype.
     -- The value is a table of all the list patterns that the filetype implements.
-    -- See how to define your custom list below
-    -- You can see a few preloaded options in the default configuration such as "unordered" and "digit"
-    -- of which the full set you can find in the config.list_patterns
+    -- See how to define your custom list below in the readme.
     -- You must put the file name for the filetype, not the file extension
     -- To get the "file name", it is just =:set filetype?= or =:se ft?=.
     markdown = {
-      "unordered",
-      "digit",
-      "ascii", -- specifies activate the ascii list type for markdown files
-      "roman", -- see below on the list types
+      list_patterns.unordered,
+      list_patterns.digit,
+      list_patterns.ascii, -- for example this specifies activate the ascii list
+      list_patterns.roman, -- type for markdown files.
     },
     text = {
-      "unordered",
-      "digit",
-      "ascii",
-      "roman",
+      list_patterns.unordered,
+      list_patterns.digit,
+      list_patterns.ascii,
+      list_patterns.roman,
     },
     norg = {
-        "neorg_1",
-        "neorg_2",
-        "neorg_3",
-        "neorg_4",
-        "neorg_5",
+        list_patterns.neorg_1,
+        list_patterns.neorg_2,
+        list_patterns.neorg_3,
+        list_patterns.neorg_4,
+        list_patterns.neorg_5,
     },
-    tex = { "latex_item" },
-    plaintex = { "latex_item" },
-  },
-  list_patterns = { -- custom list types: see README -> Configuration -> defining custom lists
-    neorg_1 = "%-",
-    neorg_2 = "%-%-",
-    neorg_3 = "%-%-%-",
-    neorg_4 = "%-%-%-%-",
-    neorg_5 = "%-%-%-%-%-",
-    unordered = "[-+*]", -- - + *
-    digit = "%d+[.)]", -- 1. 2. 3.
-    ascii = "%a[.)]", -- a) b) c)
-    roman = "%u*[.)]", -- I. II. III.
-    latex_item = "\\item",
+    tex = { list_patterns.latex_item },
+    plaintex = { list_patterns.latex_item },
   },
   checkbox = {
     left = "%[", -- the left checkbox delimiter (you could change to "%(" for brackets)
@@ -64,25 +63,12 @@ local default_config = {
   -- this is all based on lua patterns, see "Defining custom lists" for a nice article to learn them
 }
 
-local function get_preloaded_pattern(config, pre)
-	local val = config.list_patterns[pre]
-	-- if the option is not in preloaded_lists return the pattern
-	if not val then return pre end
-	return val
-end
-
 local M = vim.deepcopy(default_config)
 
 M.update = function(opts)
 	local newconf = vim.tbl_deep_extend("force", default_config, opts or {})
 
 	if not newconf.enabled then return end
-
-	for filetype, patterns in pairs(newconf.lists) do
-		for i, pattern in pairs(patterns) do
-			patterns[i] = get_preloaded_pattern(newconf, pattern)
-		end
-	end
 
 	for k, v in pairs(newconf) do
 		M[k] = v

--- a/lua/autolist/config.lua
+++ b/lua/autolist/config.lua
@@ -31,7 +31,7 @@ local default_config = {
     -- The value is a table of all the list patterns that the filetype implements.
     -- See how to define your custom list below in the readme.
     -- You must put the file name for the filetype, not the file extension
-    -- To get the "file name", it is just =:set filetype?= or =:se ft?=.
+    -- To get the "file name", it is just `:set filetype?` or `:se ft?`.
     markdown = {
       list_patterns.unordered,
       list_patterns.digit,
@@ -44,12 +44,12 @@ local default_config = {
       list_patterns.ascii,
       list_patterns.roman,
     },
-    norg = {
-        list_patterns.neorg_1,
-        list_patterns.neorg_2,
-        list_patterns.neorg_3,
-        list_patterns.neorg_4,
+    norg = { -- must be reversed
         list_patterns.neorg_5,
+        list_patterns.neorg_4,
+        list_patterns.neorg_3,
+        list_patterns.neorg_2,
+        list_patterns.neorg_1,
     },
     tex = { list_patterns.latex_item },
     plaintex = { list_patterns.latex_item },

--- a/lua/autolist/config.lua
+++ b/lua/autolist/config.lua
@@ -31,7 +31,7 @@ local default_config = {
       "ascii",
       "roman",
     },
-    neorg = {
+    norg = {
         "neorg_1",
         "neorg_2",
         "neorg_3",

--- a/lua/autolist/config.lua
+++ b/lua/autolist/config.lua
@@ -5,11 +5,13 @@ local default_config = {
     indent_raw = true, -- above, but doesn't need to be in a list to work
     preferred = "-", -- what the new list starts with (can be `1.` etc)
   },
-  invert = { -- Inverts the list type (ol -> ul, ul -> ol, [ ] -> [x])
-    indent = false, -- when on top level list, pressing invert inverts the list and indents it
-    toggles_checkbox = true, -- if pressing invert toggles checkbox
-    ul_marker = "-", -- when from ordered list to unordered, set marker to whatever this is
-    ol_incrementable = "1", -- same thing above but for ordered
+  cycle = { -- Cycles the list type in order
+      "-",   -- whatever you put here will match the first item in your list
+      "*",   -- for example if your list started with a `-` it would go to `*`
+      "1.",  -- this says that if your list starts with a `*` it would go to `1.`
+      "1)",  -- this all leverages the power of recalculate.
+      "a)",  -- i spent many hours on that function
+      "I.",  -- try it, change the first bullet in a list to `a)`, and press recalculate
   },
   lists = { -- configures list behaviours
     -- Each key in lists represents a filetype.

--- a/lua/autolist/init.lua
+++ b/lua/autolist/init.lua
@@ -21,7 +21,7 @@ M.setup = function(opts)
 end
 
 M.create_mapping_hook = function(mode, mapping, func, alias)
-    print("autolist.nvim: Function has been depreceated. See v3.0.0 changelog on github.")
+    print("autolist.nvim: There has been a major update. Please read README again for guide.")
 end
 
 return M

--- a/lua/autolist/init.lua
+++ b/lua/autolist/init.lua
@@ -20,31 +20,4 @@ M.setup = function(opts)
 	end
 end
 
-M.create_mapping_hook = function(mode, mapping, func, alias)
-	local additional_function = nil
-	local maps = vim.api.nvim_get_keymap(mode)
-	for _, map in ipairs(maps) do
-		if map.lhs == mapping then
-			if map.rhs then
-				additional_function = map.rhs:gsub("^v:lua%.", "", 1)
-			else
-				additional_function = map.callback
-			end
-			pcall(vim.keymap.del, mode, mapping)
-		end
-	end
-	vim.keymap.set(mode, mapping, function(motion)
-		local additional_map = nil
-		if additional_function then
-			if type(additional_function) == "string" then
-				local ok, res = pcall(load("return " .. additional_function))
-				if ok then additional_map = res or "" end
-			else
-				additional_map = additional_function() or ""
-			end
-		end
-		return func(motion, additional_map or alias or mapping) or ""
-	end, { expr = true })
-end
-
 return M

--- a/lua/autolist/init.lua
+++ b/lua/autolist/init.lua
@@ -2,10 +2,21 @@ local config = require("autolist.config")
 
 local M = {}
 
+local function snake_to_pascal_case(snake_str)
+  snake_str = snake_str:gsub("^(%l)", function (l) return l:upper() end, 1)
+  return snake_str:gsub("_(%l)", function (l) return l:upper() end)
+end
+
 M.setup = function(opts)
 	config.update(opts)
 	for k, v in pairs(require("autolist.auto")) do
 		M[k] = v
+        vim.cmd("command! "
+                .. "Autolist"
+                .. snake_to_pascal_case(k)
+                .. " lua require('autolist')."
+                .. k
+                .. "()")
 	end
 end
 

--- a/lua/autolist/init.lua
+++ b/lua/autolist/init.lua
@@ -20,4 +20,8 @@ M.setup = function(opts)
 	end
 end
 
+M.create_mapping_hook = function(mode, mapping, func, alias)
+    print("autolist.nvim: Function has been depreceated. See v3.0.0 changelog on github.")
+end
+
 return M

--- a/lua/autolist/utils.lua
+++ b/lua/autolist/utils.lua
@@ -76,8 +76,8 @@ function M.set_line_marker(linenum, marker, list_types, checkbox)
 	local line = fn.getline(linenum)
 	line = line:gsub("%s*$", "", 1)
 	line = line:gsub(
-		"^(%s*)" .. M.get_marker_pat(line, list_types) .. "%s*",
-		"%1" .. (marker or "") .. " ",
+		"^(%s*)" .. M.get_marker_pat(line, list_types) .. "(%s*)",
+		"%1" .. (marker or "") .. "%2",
 		1
 	)
 	if checkbox then line = line .. " " end

--- a/lua/autolist/utils.lua
+++ b/lua/autolist/utils.lua
@@ -72,7 +72,7 @@ end
 -- ================================ setters ==( set, reset )================ --
 
 -- change the list marker of the current line
-function M.set_line_marker(linenum, marker, list_types, checkbox)
+function M.set_line_marker(linenum, marker, list_types)
 	local line = fn.getline(linenum)
 	line = line:gsub("%s*$", "", 1)
 	line = line:gsub(
@@ -80,7 +80,6 @@ function M.set_line_marker(linenum, marker, list_types, checkbox)
 		"%1" .. (marker or "") .. "%2",
 		1
 	)
-	if checkbox then line = line .. " " end
 	fn.setline(linenum, line)
 	M.reset_cursor_column(fn.col("$"))
 end


### PR DESCRIPTION
overhaul everything

- [x] delete unused dot repeat which kills which-key support (#65). dot-repeat is not used very much anyways.
- [x] refactor M.new (fixes #68)
- [x] add cycle function that cycles list types (with dot repeat) (#67)
- [x] add function to toggle if list is checkbox list  (#67)
- [x] redo list patterns
- [x] touch up the docs
- [x] `neorg/asciidoc` support (#30)