### PR TITLE
feat: customizable tab length

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ local default_config = {
     right = "%]", -- the right checkbox delim (same customisation as above)
     fill = "x", -- if you do the above two customisations, your checkbox could be (x) instead of [x]
   },
+  -- which buffer-local option to use to compute tab length;
+  -- currently supports "tabstop", "shiftwidth", or supplying your own function (see :h 'tabstop')
+  tablength = "tabstop",
 
   -- this is all based on lua patterns, see "Defining custom lists" for a nice article to learn them
 }

--- a/lua/autolist/auto.lua
+++ b/lua/autolist/auto.lua
@@ -35,6 +35,23 @@ local function get_lists()
   return config.lists[vim.bo.filetype]
 end
 
+-- returns the tab length value for the current buffer
+local function tablength()
+  if not vim.bo.expandtab then
+    -- just for logistics, corresponds to a single \t character
+    return 1
+  end
+  return config.tablength()
+end
+
+-- returns the tab string for the current buffer
+local function get_tab()
+  if not vim.bo.expandtab then
+    return "\t"
+  end
+  return utils.tablength2spaces(tablength())
+end
+
 -- recalculates the current list scope
 function M.recalculate(override_start_num)
   -- the var base names: list and line
@@ -84,7 +101,7 @@ function M.recalculate(override_start_num)
         prev_indent = -1 -- escaped the child list
       elseif
         line_indent ~= prev_indent -- small difference between var names
-        and line_indent == list_indent + config.tabstop
+        and line_indent == list_indent + tablength()
       then
         -- this part recalculates a child list with recursion
         -- the prev_indent prevents it from recalculating multiple times.
@@ -160,7 +177,7 @@ function M.new_bullet(prev_line_override)
   if prev_line:match(pat_colon)
     and (config.colon.indent_raw
     or (bullet and config.colon.indent)) then
-    bullet = config.tab .. prev_line:match("^%s*") .. config.colon.preferred .. " "
+    bullet = get_tab() .. prev_line:match("^%s*") .. config.colon.preferred .. " "
   end
 
   if bullet then -- insert bullet

--- a/lua/autolist/config.lua
+++ b/lua/autolist/config.lua
@@ -59,11 +59,21 @@ local default_config = {
     right = "%]", -- the right checkbox delim (same customisation as above)
     fill = "x", -- if you do the above two customisations, your checkbox could be (x) instead of [x]
   },
+  -- which buffer-local option to use as tabstop; currently supports "tabstop",
+  -- "shiftwidth", or supplying your own function (see :h 'tabstop')
+  tablength = "tabstop",
 
   -- this is all based on lua patterns, see "Defining custom lists" for a nice article to learn them
 }
 
 local M = vim.deepcopy(default_config)
+
+local tablength_getter = {
+  tabstop = function ()
+    return vim.bo.tabstop
+  end,
+  shiftwidth = vim.fn.shiftwidth,
+}
 
 M.update = function(opts)
 	local newconf = vim.tbl_deep_extend("force", default_config, opts or {})
@@ -76,20 +86,10 @@ M.update = function(opts)
 
 	-- options that are hidden from config options but accessible by the scripts
 	M.list_cap = 50
-	M.tabstop = vim.opt.tabstop:get()
-	if vim.opt.expandtab:get() then
-		local pattern = ""
-		-- pattern is tabstop in the form of spaces
-		for i = 1, M.tabstop, 1 do
-			pattern = pattern .. " "
-		end
-		M.tab = pattern
-	else
-		M.tab = "\t"
-		-- just for logistics
-		M.tabstop = 1 -- honestly i bet tmr i will not know why i did this
-	end
 	M.recal_full = false
+	if not vim.is_callable(M.tablength) then
+		M.tablength = tablength_getter[M.tablength]
+	end
 end
 
 return M

--- a/lua/autolist/utils.lua
+++ b/lua/autolist/utils.lua
@@ -69,6 +69,36 @@ local function char_to_number(char)
 	return char:byte() - string.byte("a") + 1
 end
 
+---Caches/memoizes the output of a function
+---@generic T1, T2
+---@param func fun(s: T1): T2, any?
+---@return fun(s:T1): T2
+function M.cache(func)
+	local mem = {}
+	return function(s)
+		local cached = mem[s]
+		if cached == nil then
+			cached = func(s)
+			mem[s] = cached
+		end
+		return cached
+	end
+end
+
+M.tablength2spaces = M.cache(
+	---Formats a number of spaces into the actual string
+	---@param tablength integer
+	---@return string
+	function(tablength)
+		local pattern = ""
+		-- pattern is tablength in the form of spaces
+		for _ = 1, tablength, 1 do
+			pattern = pattern .. " "
+		end
+		return pattern
+	end
+)
+
 -- ================================ setters ==( set, reset )================ --
 
 -- change the list marker of the current line


### PR DESCRIPTION
- Uses the buffer-local instead of the global option for e.g. 'tabstop';
- Adds a "tablength" option that can be used to switch from 'tabstop' to 'shiftwidth', or to a user-specified function entirely.

The use case for this is that [vim-sleuth](https://github.com/tpope/vim-sleuth) (which detects file indentation length) only sets the 'shiftwidth' and 'expandtabs' options.

Hope this helps :)